### PR TITLE
adsc support namespace and lables

### DIFF
--- a/cmd/adsc.go
+++ b/cmd/adsc.go
@@ -10,13 +10,15 @@ import (
 )
 
 var adscConfig = model.AdscConfig{
-	Delay: time.Millisecond * 10,
-	Count: 1,
+	Delay:     time.Millisecond * 10,
+	Count:     1,
+	Namespace: "default",
 }
 
 func init() {
 	adscCmd.PersistentFlags().DurationVar(&adscConfig.Delay, "delay", adscConfig.Delay, "delay between each connection")
 	adscCmd.PersistentFlags().IntVar(&adscConfig.Count, "count", adscConfig.Count, "number of adsc connections to make")
+	adscCmd.PersistentFlags().StringVar(&adscConfig.Namespace, "namespace", adscConfig.Namespace, "namespace of simulation")
 }
 
 var adscCmd = &cobra.Command{

--- a/pkg/simulation/model/model.go
+++ b/pkg/simulation/model/model.go
@@ -148,8 +148,9 @@ type DumpConfig struct {
 }
 
 type AdscConfig struct {
-	Count int
-	Delay time.Duration
+	Count     int
+	Delay     time.Duration
+	Namespace string
 }
 
 type Selector string

--- a/pkg/simulation/simulations.go
+++ b/pkg/simulation/simulations.go
@@ -111,13 +111,14 @@ func Adsc(a model.Args) error {
 
 	for i := 0; i < count; i++ {
 		sims = append(sims, &xds.Simulation{
-			Namespace: "default",
+			Namespace: a.AdsConfig.Namespace,
 			Name:      "adsc",
 			IP:        util.GetIP(),
 			// TODO: multicluster
 			Cluster:  "Kubernetes",
 			GrpcOpts: opts,
 			Delta:    a.DeltaXDS,
+			Labels:   a.Metadata,
 		})
 	}
 	return ExecuteSimulations(a, model.AggregateSimulation{Simulations: sims, Delay: a.AdsConfig.Delay})


### PR DESCRIPTION
When we export the online istio cr to the offline environment for testing, we need to use adsc to simulate xDS clients with named namespaces and labels.